### PR TITLE
Fix: Make protect any changes when DoveProject is_locked == true to a…

### DIFF
--- a/programs/dove/src/instructions/create_dove_fund.rs
+++ b/programs/dove/src/instructions/create_dove_fund.rs
@@ -35,6 +35,8 @@ pub fn handler(
     let dove_fund: &mut Account<DoveFund> = &mut ctx.accounts.dove_fund;
     let dove_project: &mut Account<DoveProject> = &mut ctx.accounts.dove_project;
 
+    require!(!dove_project.is_locked, ErrorCode::DoveProjectIsLocked);
+
     require!(
         amount_pooled > DoveFund::MIN_AMOUNT_TO_POOLED,
         ErrorCode::TooSmallAmountPooled

--- a/programs/dove/src/instructions/delete_dove_fund.rs
+++ b/programs/dove/src/instructions/delete_dove_fund.rs
@@ -32,6 +32,8 @@ pub fn handler(ctx: Context<DeleteDoveFund>) -> Result<()> {
         ErrorCode::InvalidProjectToDeleteDoveFund
     );
 
+    require!(!dove_project.is_locked, ErrorCode::DoveProjectIsLocked);
+
     require!(
         dove_fund.amount_pooled >= DoveFund::MIN_AMOUNT_TO_POOLED,
         ErrorCode::TooSmallAmountPooled

--- a/programs/dove/src/instructions/update_dove_fund.rs
+++ b/programs/dove/src/instructions/update_dove_fund.rs
@@ -42,6 +42,8 @@ pub fn handler(
         ErrorCode::InvalidProjectToUpdateDoveFund
     );
 
+    require!(!dove_project.is_locked, ErrorCode::DoveProjectIsLocked);
+
     require!(
         new_amount_pooled > DoveFund::MIN_AMOUNT_TO_POOLED,
         ErrorCode::TooSmallAmountPooled

--- a/programs/dove/src/instructions/update_dove_project.rs
+++ b/programs/dove/src/instructions/update_dove_project.rs
@@ -39,6 +39,8 @@ pub fn handler(
         ErrorCode::InvalidUserToUpdateDoveProject
     );
 
+    require!(!project.is_locked, ErrorCode::DoveProjectIsLocked);
+
     require!(
         evidence_link.len() <= DoveProject::MAX_HYPERLINK,
         ErrorCode::TooLongEvidenceLink

--- a/programs/dove/src/model.rs
+++ b/programs/dove/src/model.rs
@@ -21,7 +21,7 @@ pub trait SizeDef {
     const SIZE: usize = 0;
 
     const ACCEPTABLE_AMOUNT_ERROR: u64 = 1000;
-    const ACCEPTABLE_DATE_ERROR: u64 = 1000000;
+    const ACCEPTABLE_DATE_ERROR: u64 = 3000000;
 
     fn get_now_as_unix_time() -> i64 {
         return Clock::get().unwrap().unix_timestamp;

--- a/tests/test_pull_dove_fund.ts
+++ b/tests/test_pull_dove_fund.ts
@@ -302,6 +302,17 @@ describe("test_pull_dove_fund", () => {
             assert.ok(e.message.includes("InconsistentUpdateDate"));
         }
 
+        try {
+            await pullDoveFund(
+                doveFund0,
+                doveProject,
+                program,
+                admin,
+            );
+        } catch (e) {
+            assert.ok(e.message.includes("DoveProjectIsNotLocked"));
+        }
+
         const pull_dove_project_date = getNow();
         const pull_dove_project = await pullDoveProject(
             doveProject,

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -3,7 +3,7 @@ import { Program, web3, utils } from "@project-serum/anchor";
 import { SystemProgram } from "@solana/web3.js";
 import { Dove } from "../target/types/dove";
 
-const ACCEPTABLE_DATE_ERROR = 1000000;
+const ACCEPTABLE_DATE_ERROR = 3000000;
 export const equalDateTime = (dateTime1: number, dateTime2: number): boolean => {
     return Math.abs(dateTime1 - dateTime2) < ACCEPTABLE_DATE_ERROR;
 }


### PR DESCRIPTION
…void any data contamination #36

 - programs/dove/src/instructions/create_dove_fund.rs
 - programs/dove/src/instructions/delete_dove_fund.rs
 - programs/dove/src/instructions/update_dove_fund.rs
 - programs/dove/src/instructions/update_dove_project.rs
   - Protecting DoveProject and DoveFund during the DoveProject has being locked.
 - programs/dove/src/model.rs
   - Acceptable time window should be extended.
 - tests/test_pull_dove_fund.ts
 - tests/test_pull_dove_project.ts
 - tests/util.ts
   - Update the tests to adopt the above changes.